### PR TITLE
minor fix in NoteNameQuestion.check_question: now using user input

### DIFF
--- a/src/birdears/questions/notename.py
+++ b/src/birdears/questions/notename.py
@@ -146,17 +146,16 @@ class NoteNameQuestion(QuestionBase):
         global INTERVALS
 
         from ..scale import ChromaticScale
-        c_chromatic = ChromaticScale(tonic='C', n_octaves=2)
-        # question_tone_chromatic = ChromaticScale(tonic=self.tonic_str,
-        #                                         octave=self.octave,
-        #                                         n_octaves = self.n_octaves)
+        question_tone_chromatic = ChromaticScale(tonic=self.tonic_str,
+                                                octave=self.octave,
+                                                n_octaves = self.n_octaves)
 
         keyboard_index = \
             KEYBOARD_INDICES['chromatic']['ascending']['major']
 
         user_semitones = keyboard_index.index(user_input_char[0])
 
-        user_pitch = c_chromatic[user_semitones]
+        user_pitch = question_tone_chromatic[user_semitones]
         user_note = user_pitch.note
 
         correct_semitones = abs(int(self.tonic_pitch) - int(self.random_pitch))


### PR DESCRIPTION
Hi!, I tried to fix a single line in `NoteNameQuestion.check_question`, which seemed to make the program to not properly consider the tonic note input by the user. In particular, in `NoteNameQuestion.check_question`, line 149, there was the following:
```
c_chromatic = ChromaticScale(tonic='C', n_octaves=2)
```
which generated errors when calling birdeards with `notename -t some_note_that_is_not_C`.
I replaced the previous line with the following, which was commented:
```
        # question_tone_chromatic = ChromaticScale(tonic=self.tonic_str,
        #                                         octave=self.octave,
        #                                         n_octaves = self.n_octaves)
```
also, changing every occurrence of `c_chromatic` for `question_tone_chromatic`. Now it seems to work fine. Let me know if I made some mistake in here.